### PR TITLE
BUGFIX - Realtor-restricted tabs require an resource restart

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -88,6 +88,10 @@ end
 RegisterNetEvent("QBCore:Client:OnJobUpdate", setRealtor)
 
 AddEventHandler('QBCore:Client:OnPlayerLoaded', function()
+	SendNUIMessage({
+		action = "setConfig",
+		data = Config.RealtorPerms
+	})
     local PlayerData = QBCore.Functions.GetPlayerData()
 	setRealtor(PlayerData.job)
 end)


### PR DESCRIPTION
(that was a lot of R's)

# Overview
This PR fixes the problem with ps-realtor's realtor tabs only working after a resource restart after the given user has loaded in.

# Details
Essentially copied what ps-realtor does when the resource starts, and pasted it to also do it when a player loads in.

# UI Changes / Functionality
Tabs now work without restarting the resource
![image](https://github.com/Project-Sloth/ps-realtor/assets/90502234/7f92d9d3-d249-4fc5-96f5-b7d457f19d46)


# Testing Steps
Before:
Start server, Load in, open /housing - no tabs. Restart ps-realtor - tabs appear.
After: 
Start server, load in, open /housing - tabs appear.

- [x] Did you test the changes you made?
- [x] Did you test core functionality of the script to ensure your changes do not regress other areas?
- [ ] Did you test your changes in multiplayer to ensure it works correctly on all clients?
