### PR TITLE
Remove unnecessary NUI callback

### DIFF
--- a/ui/src/components/apartments/ApartmentCard.svelte
+++ b/ui/src/components/apartments/ApartmentCard.svelte
@@ -20,10 +20,7 @@
         const arrCitizenids = $PROPERTIES.filter((property) => property.apartment === apartmentName).map((property) => property.owner);
 
         if (arrCitizenids.length !== 0 && arrCitizenids[0] !== undefined) {
-            SendNUI('getNames', arrCitizenids).then((names: string[]) => {
-                tenants = names;
-                apartmentData.currentTenants = tenants.length;
-            })
+            apartmentData.currentTenants = arrCitizenids.length;
         } else {
             apartmentData.currentTenants = 0;
         }
@@ -42,7 +39,7 @@
 
         <div class="location-tenants-info">
             <img src="images/user-location-pin.png" alt="User Location Icon" />
-            <p>{tenants.length || 0} Global Tenants</p>
+            <p>{apartmentData.currentTenants || 0} Global Tenants</p>
         </div>
 
         <button class="select-apt-button">


### PR DESCRIPTION
# Overview
Removes an unnecessary call to the getNames NUI callback in the apartment card page which is probably left over from a previous version.

# Details
This is no longer needed as we don't display any of that information here. This is just putting unnecessary load on the server especially when there's a lot of tenants.

# Testing Steps
1. Open realtor menu
2. Navigate to apartments tab
3. Notice no visible difference

- [x] Did you test the changes you made?
- [x] Did you test core functionality of the script to ensure your changes do not regress other areas?
- [x] Did you test your changes in multiplayer to ensure it works correctly on all clients?
