### PR TITLE
Add support for multiple realtor jobs

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -73,7 +73,7 @@ RegisterNUICallback("hideUI", function()
 end)
 
 local function setRealtor(jobInfo)
-	if jobInfo.name == Config.RealtorJobName then
+	if RealtorJobs[jobInfo.name] then
 		SendNUIMessage({
 			action = "setRealtorGrade",
 			data = jobInfo.grade.level

--- a/server/server.lua
+++ b/server/server.lua
@@ -10,7 +10,7 @@ RegisterNetEvent("bl-realtor:server:updateProperty", function(type, property_id,
     local src = source
     local Player = QBCore.Functions.GetPlayer(src)
     local PlayerData = Player.PlayerData
-    if not PlayerData.job.name == Config.RealtorJobName then return false end
+    if not RealtorJobs[PlayerData.job.name] then return false end
 
     data.realtorSrc = src
     -- Update property
@@ -22,7 +22,7 @@ RegisterNetEvent("bl-realtor:server:registerProperty", function(data)
     local src = source
     local Player = QBCore.Functions.GetPlayer(src)
     local PlayerData = Player.PlayerData
-    if not PlayerData.job.name == Config.RealtorJobName then return false end
+    if not RealtorJobs[PlayerData.job.name] then return false end
 
     data.realtorSrc = src
     -- Register property
@@ -34,7 +34,7 @@ RegisterNetEvent("bl-realtor:server:addTenantToApartment", function(data)
     local src = source
     local Player = QBCore.Functions.GetPlayer(src)
     local PlayerData = Player.PlayerData
-    if not PlayerData.job.name == Config.RealtorJobName then return false end
+    if not RealtorJobs[PlayerData.job.name] then return false end
 
     data.realtorSrc = src
     -- Add tenant
@@ -45,7 +45,7 @@ lib.callback.register("bl-realtor:server:getNames", function (source, data)
     local src = source
     local Player = QBCore.Functions.GetPlayer(src)
     local PlayerData = Player.PlayerData
-    if not PlayerData.job.name == Config.RealtorJobName then return false end
+    if not RealtorJobs[PlayerData.job.name] then return false end
     
     local names = {}
     for i = 1, #data do

--- a/shared/config.lua
+++ b/shared/config.lua
@@ -1,7 +1,11 @@
 Config = Config or {}
 
--- Set your Real Estate here
-Config.RealtorJobName = "realestate"
+-- Set your Real Estate jobs here
+Config.RealtorJobNames = { -- add multiple realestate jobs that are allowed to sell properties!
+    "realestate",
+    -- "realestate2",
+    -- "realestate3",
+}
 
 -- Set this value to true if you want to use the command to open the Housing Menu(Realtor Menu)
 Config.UseCommand = true
@@ -29,3 +33,10 @@ Config.RealtorPerms = {
     deleteProperty = 2, --minimum grade to delete property | default 2
     setApartments = 2, --minimum grade to set apartments for players | default 2
 }
+
+RealtorJobs = {}
+
+-- Convert config table to usable keys
+for i = 1, #Config.RealtorJobNames do
+    RealtorJobs[Config.RealtorJobNames[i]] = true
+end


### PR DESCRIPTION
# Overview
This pull request adds support for multiple realtor jobs. Just like https://github.com/Project-Sloth/ps-housing/pull/207. The exact same thing was done here, except the `RealtorJobs` logic is placed in the `shared/config.lua` file since there is no `framework.lua` and it's such a small piece of code.

More details in https://github.com/Project-Sloth/ps-housing/pull/207.

# Details
See https://github.com/Project-Sloth/ps-housing/pull/207.

# UI Changes / Functionality
`Config.RealtorJobName` was changed to `Config.RealtorJobNames` and is now an array of job names. It uses the same mechanism as `Config.PoliceJobNames` from ps-housing to check for the jobs. It's nothing visible in the UI, just that you're able to sell houses with different jobs.

# Testing Steps
1. Add jobs to `Config.RealtorJobNames`.
2. See that `/housing` still fully works.

- [x] Did you test the changes you made?
- [x] Did you test core functionality of the script to ensure your changes do not regress other areas?
- [x] Did you test your changes in multiplayer to ensure it works correctly on all clients?
